### PR TITLE
Issue #5: Card-centric capabilities UX with inline registration

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,7 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
   const capabilitiesList = document.getElementById("capabilities-list");
-  const capabilitySelect = document.getElementById("capability");
-  const registerForm = document.getElementById("register-form");
   const messageDiv = document.getElementById("message");
 
   // Function to fetch capabilities from API
@@ -41,31 +39,84 @@ document.addEventListener("DOMContentLoaded", () => {
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Practice Area:</strong> ${details.practice_area}</p>
+          <p><strong>Skill Levels:</strong> ${details.skill_levels ? details.skill_levels.join(', ') : 'Not specified'}</p>
+          <p><strong>Certifications:</strong> ${details.certifications ? details.certifications.join(', ') : 'Not specified'}</p>
           <p><strong>Industry Verticals:</strong> ${details.industry_verticals ? details.industry_verticals.join(', ') : 'Not specified'}</p>
           <p><strong>Capacity:</strong> ${availableCapacity} hours/week available</p>
           <p><strong>Current Team:</strong> ${currentConsultants} consultants</p>
+          <div class="register-inline">
+            <h5>Register Expertise</h5>
+            <form class="card-form" data-capability="${name}">
+              <input type="email" name="email" required placeholder="consultant@slalom.com" aria-label="Consultant email for ${name}" />
+              <button type="submit" class="register-btn">Register</button>
+            </form>
+          </div>
           <div class="consultants-container">
             ${consultantsHTML}
           </div>
         `;
 
         capabilitiesList.appendChild(capabilityCard);
-
-        // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        capabilitySelect.appendChild(option);
       });
 
       // Add event listeners to delete buttons
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
+
+      // Add event listeners to inline register forms
+      document.querySelectorAll(".card-form").forEach((form) => {
+        form.addEventListener("submit", handleRegister);
+      });
     } catch (error) {
       capabilitiesList.innerHTML =
         "<p>Failed to load capabilities. Please try again later.</p>";
       console.error("Error fetching capabilities:", error);
+    }
+  }
+
+  // Handle register functionality from a capability card
+  async function handleRegister(event) {
+    event.preventDefault();
+    const form = event.target;
+    const capability = form.getAttribute("data-capability");
+    const emailInput = form.querySelector("input[name='email']");
+    const email = emailInput.value.trim();
+
+    try {
+      const response = await fetch(
+        `/capabilities/${encodeURIComponent(
+          capability
+        )}/register?email=${encodeURIComponent(email)}`,
+        {
+          method: "POST",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        form.reset();
+
+        // Refresh capabilities list to show updated consultants
+        fetchCapabilities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to register. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error registering:", error);
     }
   }
 
@@ -111,51 +162,6 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error unregistering:", error);
     }
   }
-
-  // Handle form submission
-  registerForm.addEventListener("submit", async (event) => {
-    event.preventDefault();
-
-    const email = document.getElementById("email").value;
-    const capability = document.getElementById("capability").value;
-
-    try {
-      const response = await fetch(
-        `/capabilities/${encodeURIComponent(
-          capability
-        )}/register?email=${encodeURIComponent(email)}`,
-        {
-          method: "POST",
-        }
-      );
-
-      const result = await response.json();
-
-      if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-        registerForm.reset();
-
-        // Refresh capabilities list to show updated consultants
-        fetchCapabilities();
-      } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
-      }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
-    } catch (error) {
-      messageDiv.textContent = "Failed to register. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
-      console.error("Error registering:", error);
-    }
-  });
 
   // Initialize app
   fetchCapabilities();

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -19,30 +19,15 @@
 
     <main>
       <section id="capabilities-container">
-        <h3>Available Capabilities</h3>
-        <div id="capabilities-list">
+        <div class="section-heading">
+          <h3>Capabilities Hub</h3>
+          <p>Browse capabilities and register directly from each card.</p>
+        </div>
+        <div id="message" class="hidden"></div>
+        <div id="capabilities-list" class="capabilities-grid">
           <!-- Capabilities will be loaded here -->
           <p>Loading capabilities...</p>
         </div>
-      </section>
-
-      <section id="register-container">
-        <h3>Register Your Expertise</h3>
-        <form id="register-form">
-          <div class="form-group">
-            <label for="email">Consultant Email:</label>
-            <input type="email" id="email" required placeholder="your-email@slalom.com" />
-          </div>
-          <div class="form-group">
-            <label for="capability">Select Capability:</label>
-            <select id="capability" required>
-              <option value="">-- Select a capability --</option>
-              <!-- Capability options will be loaded here -->
-            </select>
-          </div>
-          <button type="submit">Register Expertise</button>
-        </form>
-        <div id="message" class="hidden"></div>
       </section>
     </main>
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -9,10 +9,10 @@ body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
   color: #333;
-  max-width: 1200px;
+  max-width: 1280px;
   margin: 0 auto;
   padding: 20px;
-  background-color: #f5f5f5;
+  background: radial-gradient(circle at 20% 0%, #e8f1ff 0%, #f5f5f5 45%, #eef5ff 100%);
 }
 
 header {
@@ -52,16 +52,7 @@ header {
 }
 
 main {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 30px;
-  justify-content: center;
-}
-
-@media (min-width: 768px) {
-  main {
-    grid-template-columns: 2fr 1fr;
-  }
+  display: block;
 }
 
 section {
@@ -70,7 +61,7 @@ section {
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   width: 100%;
-  max-width: 500px;
+  max-width: 100%;
 }
 
 section h3 {
@@ -81,8 +72,26 @@ section h3 {
   font-size: 1.4rem;
 }
 
+#capabilities-container {
+  border-radius: 12px;
+}
+
+.section-heading {
+  margin-bottom: 16px;
+}
+
+.section-heading p {
+  color: #4b5f7a;
+  margin-top: -8px;
+}
+
+.capabilities-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
 .capability-card {
-  margin-bottom: 20px;
   padding: 20px;
   border: 2px solid #e3f2fd;
   border-radius: 10px;
@@ -174,7 +183,7 @@ section h3 {
 }
 
 .form-group {
-  margin-bottom: 15px;
+  margin-bottom: 10px;
 }
 
 .form-group label {
@@ -186,33 +195,48 @@ section h3 {
 .form-group input,
 .form-group select {
   width: 100%;
-  padding: 10px;
+  padding: 9px;
   border: 1px solid #ddd;
   border-radius: 4px;
-  font-size: 16px;
+  font-size: 14px;
 }
 
-button[type="submit"] {
+.register-inline {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid #e3f2fd;
+}
+
+.card-form {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.card-form input {
+  flex: 1;
+}
+
+.register-btn {
   background: linear-gradient(135deg, #003d7a, #0066cc);
   color: white;
   border: none;
-  padding: 12px 20px;
-  font-size: 16px;
+  padding: 10px 14px;
+  font-size: 14px;
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.3s ease;
   font-weight: bold;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+  white-space: nowrap;
 }
 
-button[type="submit"]:hover {
+.register-btn:hover {
   background: linear-gradient(135deg, #0066cc, #1976d2);
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 61, 122, 0.3);
 }
 
-.message {
+#message {
   margin-top: 20px;
   padding: 10px;
   border-radius: 4px;
@@ -287,6 +311,10 @@ footer {
 
 /* Responsive design improvements */
 @media (max-width: 768px) {
+  body {
+    padding: 12px;
+  }
+
   .header-content {
     flex-direction: column;
     gap: 10px;
@@ -303,5 +331,14 @@ footer {
   
   .header-text h2 {
     font-size: 1rem;
+  }
+
+  .capabilities-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-form {
+    flex-direction: column;
+    align-items: stretch;
   }
 }


### PR DESCRIPTION
## Summary
Implements issue #5 by redesigning the frontend for a more integrated, card-first capability management experience.

## What changed
- Removed standalone registration panel from the page layout
- Made capability cards the primary interface in a responsive grid
- Added inline `Register Expertise` form directly on each capability card
- Kept per-consultant unregister action on each card
- Added quick-scan metadata on cards: skill levels and certifications
- Updated responsive behavior for desktop, tablet, and mobile

## Files changed
- `src/static/index.html`
- `src/static/styles.css`
- `src/static/app.js`

## Notes
- API endpoints were unchanged (`/capabilities`, register/unregister routes)
- No backend logic changes; this is a frontend UX improvement focused on issue #5 requirements